### PR TITLE
Avoid printing to stdout and use the standard logging module instead

### DIFF
--- a/pinyin_jyutping_sentence/__init__.py
+++ b/pinyin_jyutping_sentence/__init__.py
@@ -1,6 +1,9 @@
 import re
 import jieba
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 class RomanizationConversion():
     
@@ -102,7 +105,7 @@ class RomanizationConversion():
         # extract tone
         m = re.search("([a-z]+)([0-9])", syllable)
         if m == None:
-            print("couldn't parse syllable [%s]" % syllable)
+            logger.info("couldn't parse syllable [%s]", syllable)
             return syllable
         sound = m.group(1)
         tone = int(m.group(2))
@@ -176,7 +179,7 @@ class RomanizationConversion():
     def process_line(self, line, jyutping_word_map, pinyin_word_map, jyutping_char_map, pinyin_char_map):
         m = re.match('([^\s]+)\s([^\s]+)\s\[([^\]]*)\]\s\{([^\}]+)\}\s.*', line)
         if m == None:
-            print(line)
+            logger.info(line)
         traditional_chinese = m.group(1)
         simplified_chinese = m.group(2)
         pinyin = m.group(3)
@@ -222,7 +225,7 @@ class RomanizationConversion():
     def process_cedict_line(self, line, pinyin_word_map, pinyin_char_map):
         m = re.match('([^\s]+)\s([^\s]+)\s\[([^\]]*)\]\s\/([^\/]+)\/.*', line)
         if m == None:
-            print(line)
+            logger.info(line)
         traditional_chinese = m.group(1)
         simplified_chinese = m.group(2)
         pinyin = m.group(3)
@@ -251,7 +254,7 @@ class RomanizationConversion():
 
         
     def process_file(self, filename):
-        print("opening file {}".format(filename))
+        logger.info("opening file %s", filename)
         with open(filename, 'r', encoding="utf8") as filehandle:
             for line in filehandle:
                 first_char = line[:1]
@@ -263,7 +266,7 @@ class RomanizationConversion():
                                       self.pinyin_char_map)
                     
     def process_cedict_file(self, filename):
-        print("opening file {}".format(filename))
+        logger.info("opening file %s", filename)
         with open(filename, 'r', encoding="utf8") as filehandle:
             for line in filehandle:
                 first_char = line[:1]


### PR DESCRIPTION
The previous behavior of the module made CLI programs to be consumed by other programs through pipe cannot use it, because its `print()` calls pollute programs' stdout.  For example, if a program purposes to write a valid JSON into stdout and be consumed by other program which reads a valid JSON through stdin (e.g., `jq`), the consumer program fails to parse it because its input is not a valid JSON due to the module's log messages.

Rather than printing these log messages into stdout, I changed it to use [`logging` module][1] instead.  The standard `logging` module can be handled by a client code and silences log messages by default.

[1]: https://docs.python.org/3/library/logging.html